### PR TITLE
Remove unused denpendency on FFI::TinyCC

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,7 +4,6 @@ requires "Exporter" => "0";
 requires "Exporter::Shiny" => "0";
 requires "FFI::Platypus" => "0";
 requires "FFI::Platypus::Memory" => "0";
-requires "FFI::TinyCC" => "0";
 requires "List::MoreUtils" => "0";
 requires "List::Util" => "0";
 requires "Moose" => "0";

--- a/lib/Term/Caca/FFI.pm
+++ b/lib/Term/Caca/FFI.pm
@@ -13,7 +13,6 @@ use 5.20.0;
 use Alien::caca;
 
 use FFI::Platypus;
-use FFI::TinyCC;
 
 use Exporter::Shiny qw/
     UINT_SIZE


### PR DESCRIPTION
It looks like we're no longer using FFI::TinyCC.

I ran the test suite using `carton` after removing the dependency in a system without the `tcc` binary, and it still passed, so I'm guessing this is also a remnant from the past.