### PR TITLE
Fix detection of keys in key events

### DIFF
--- a/examples/maze.pl
+++ b/examples/maze.pl
@@ -3,14 +3,10 @@
 use 5.12.0;
 
 use Games::Maze;
-use Term::Caca::Constants qw/ :colors :events /;
+use Term::Caca::Constants qw/ :colors :events :keys /;
 use Term::Caca;
 
-use experimental qw/
-    signatures
-    postderef
-    smartmatch
-/;
+use experimental qw/ postderef /;
 
 my $term = Term::Caca->new();
 
@@ -55,26 +51,24 @@ while (1) {
          or $event->char eq 'q';
 
     # move using the keypad (2, 4, 6, 8)
-    given ( $event->char ) {
-        when ( 2 ) { 
-            if ( $pos[1] < $w and $maze[$pos[1]+1][$pos[0]] eq ' ' ) {
-                $pos[1]++;
-            }
+    if ( $event->char eq 8 || $event->key == KEY_UP ) {
+        if ( $pos[1] > 0 and $maze[$pos[1]-1][$pos[0]] eq ' ' ) {
+            $pos[1]--;
         }
-        when ( 8 ) { 
-            if ( $pos[1] > 0 and $maze[$pos[1]-1][$pos[0]] eq ' ' ) {
-                $pos[1]--;
-            }
+    }
+    elsif ( $event->char eq 2 || $event->key == KEY_DOWN ) {
+        if ( $pos[1] < $w and $maze[$pos[1]+1][$pos[0]] eq ' ' ) {
+            $pos[1]++;
         }
-        when ( 4 ) { 
-            if ( $pos[0] > 0 and $maze[$pos[1]][$pos[0]-1] eq ' ' ) {
-                $pos[0]--;
-            }
+    }
+    elsif ( $event->char eq 4 || $event->key == KEY_LEFT ) {
+        if ( $pos[0] > 0 and $maze[$pos[1]][$pos[0]-1] eq ' ' ) {
+            $pos[0]--;
         }
-        when ( 6 ) { 
-            if ( $pos[0] < $w and $maze[$pos[1]][$pos[0]+1] eq ' ' ) {
-                $pos[0]++;
-            }
+    }
+    elsif ( $event->char eq 6 || $event->key == KEY_RIGHT ) {
+        if ( $pos[0] < $w and $maze[$pos[1]][$pos[0]+1] eq ' ' ) {
+            $pos[0]++;
         }
     }
 }

--- a/lib/Term/Caca/Event/Key.pm
+++ b/lib/Term/Caca/Event/Key.pm
@@ -27,10 +27,19 @@ extends 'Term::Caca::Event';
 
 Returns the character pressed or released.
 
+=method key()
+
+Returns the key code that was pressed or released.
+
+These will match the values of the constants exported by the C<:keys> tag
+from L<Term::Caca::Constants>.
+
 =cut
 
-sub char {
-    return chr Term::Caca::caca_get_event_key_ch( $_[0]->event );
+sub key {
+    return Term::Caca::caca_get_event_key_ch( $_[0]->event );
 }
+
+sub char { chr shift->key }
 
 1;

--- a/lib/Term/Caca/FFI.pm
+++ b/lib/Term/Caca/FFI.pm
@@ -106,7 +106,7 @@ $ffi->attach( 'caca_export_canvas_to_memory' => [ 'opaque', 'string', 'opaque' ]
 
 $ffi->attach( caca_set_color_ansi => [ 'opaque', 'int', 'int' ] => 'void' );
 $ffi->attach( caca_get_event_type => [ 'opaque' ] => 'int' );
-$ffi->attach( caca_get_event_key_ch => [ 'opaque' ] => 'char' );
+$ffi->attach( caca_get_event_key_ch => [ 'opaque' ] => 'int' );
 
 $ffi->attach( caca_get_event_mouse_x => [ 'opaque' ] => 'int' );
 $ffi->attach( caca_get_event_mouse_y => [ 'opaque' ] => 'int' );


### PR DESCRIPTION
This patch adds a `key` attribute to the ::Event::Key class, which can be used to match a key to the codes exported by Term::Caca::Constant.

It also modifies the maze example to make use of this, by allowing it to be controlled with the arrow keys.